### PR TITLE
Changeable classpath themes directory name

### DIFF
--- a/src/main/java/com/x5/template/TemplateSet.java
+++ b/src/main/java/com/x5/template/TemplateSet.java
@@ -125,7 +125,7 @@ public class TemplateSet implements ContentSource, ChunkFactory
      * Makes a template "factory" which reads in template files from the
      * file system in the templatePath folder.  Caches for refreshMins.
      * Uses "extensions" for the default file extension (do not include dot).
-     * @param classpathThemesFolder folder where template files are located in jar package.
+     * @param classpathThemesFolder folder where template files are located on classpath.
      * @param templatePath  folder where template files are located.
      * @param extension     appends dot plus this String to a template name stub to find template files.
      * @param refreshMins   returns template from cache unless this many minutes have passed.

--- a/src/main/java/com/x5/template/TemplateSet.java
+++ b/src/main/java/com/x5/template/TemplateSet.java
@@ -138,6 +138,11 @@ public class TemplateSet implements ContentSource, ChunkFactory
         this.defaultExtension = extension;
     }
 
+    public TemplateSet(String templatePath, String extension, int refreshMins)
+    {
+        this(null, templatePath, extension, refreshMins);
+    }
+
     /**
      * Retrieve as String the template specified by name.
      * If name contains one or more dots it is assumed that the template

--- a/src/main/java/com/x5/template/TemplateSet.java
+++ b/src/main/java/com/x5/template/TemplateSet.java
@@ -17,6 +17,7 @@ import java.util.Set;
 import com.x5.template.filters.ChunkFilter;
 import com.x5.template.filters.RegexFilter;
 import com.x5.util.JarResource;
+import com.x5.util.Path;
 
 // Project Title: Chunk
 // Description: Template Util
@@ -108,6 +109,7 @@ public class TemplateSet implements ContentSource, ChunkFactory
     private String defaultExtension = null;
     private String tagStart = DEFAULT_TAG_START;
     private String tagEnd = DEFAULT_TAG_END;
+    private String classpathThemesFolder;
     private String templatePath = System.getProperty("templateset.folder","");
     private String layerName = null;
 
@@ -123,21 +125,15 @@ public class TemplateSet implements ContentSource, ChunkFactory
      * Makes a template "factory" which reads in template files from the
      * file system in the templatePath folder.  Caches for refreshMins.
      * Uses "extensions" for the default file extension (do not include dot).
+     * @param classpathThemesFolder folder where template files are located in jar package.
      * @param templatePath  folder where template files are located.
      * @param extension     appends dot plus this String to a template name stub to find template files.
      * @param refreshMins   returns template from cache unless this many minutes have passed.
      */
-    public TemplateSet(String templatePath, String extension, int refreshMins)
+    public TemplateSet(String classpathThemesFolder, String templatePath, String extension, int refreshMins)
     {
-        if (templatePath != null) {
-            // ensure trailing fileseparator
-            char lastChar = templatePath.charAt(templatePath.length()-1);
-            char fs = System.getProperty("file.separator").charAt(0);
-            if (lastChar != '\\' && lastChar != '/' && lastChar != fs) {
-                templatePath += fs;
-            }
-            this.templatePath = templatePath;
-        }
+        this.classpathThemesFolder = Path.ensureTrailingSeparator(classpathThemesFolder);
+        this.templatePath = Path.ensureTrailingSeparator(templatePath);
         this.dirtyInterval = refreshMins;
         this.defaultExtension = extension;
     }
@@ -614,9 +610,9 @@ public class TemplateSet implements ContentSource, ChunkFactory
         String stub = TemplateDoc.truncateNameToStub(templateName);
         String path;
         if (layerName == null) {
-            path = "/themes/" + stub;
+            path = classpathThemesFolder + stub;
         } else {
-            path = "/themes/" + layerName + stub;
+            path = classpathThemesFolder + layerName + stub;
         }
         if (ext != null && ext.length() > 0) {
             path += '.' + ext;
@@ -653,10 +649,7 @@ public class TemplateSet implements ContentSource, ChunkFactory
 
     public void setLayerName(String layerName)
     {
-        this.layerName = layerName;
-        if (layerName != null && !layerName.endsWith("/")) {
-            this.layerName = this.layerName + "/";
-        }
+        this.layerName = Path.ensureTrailingSeparator(layerName);
     }
 
     public void setEncoding(String encoding)

--- a/src/main/java/com/x5/template/TemplateSet.java
+++ b/src/main/java/com/x5/template/TemplateSet.java
@@ -109,7 +109,7 @@ public class TemplateSet implements ContentSource, ChunkFactory
     private String defaultExtension = null;
     private String tagStart = DEFAULT_TAG_START;
     private String tagEnd = DEFAULT_TAG_END;
-    private String classpathThemesFolder;
+    private String classpathThemesFolder = Path.ensureTrailingSeparator("/" + Theme.DEFAULT_THEMES_FOLDER);
     private String templatePath = System.getProperty("templateset.folder","");
     private String layerName = null;
 
@@ -132,15 +132,15 @@ public class TemplateSet implements ContentSource, ChunkFactory
      */
     public TemplateSet(String classpathThemesFolder, String templatePath, String extension, int refreshMins)
     {
+        this(templatePath, extension, refreshMins);
         this.classpathThemesFolder = Path.ensureTrailingSeparator(classpathThemesFolder);
-        this.templatePath = Path.ensureTrailingSeparator(templatePath);
-        this.dirtyInterval = refreshMins;
-        this.defaultExtension = extension;
     }
 
     public TemplateSet(String templatePath, String extension, int refreshMins)
     {
-        this(null, templatePath, extension, refreshMins);
+        this.templatePath = Path.ensureTrailingSeparator(templatePath);
+        this.dirtyInterval = refreshMins;
+        this.defaultExtension = extension;
     }
 
     /**

--- a/src/main/java/com/x5/template/Theme.java
+++ b/src/main/java/com/x5/template/Theme.java
@@ -7,17 +7,19 @@ import java.util.HashSet;
 import java.util.Map;
 
 import com.x5.template.filters.ChunkFilter;
+import com.x5.util.Path;
 
 public class Theme implements ContentSource, ChunkFactory
 {
     private ArrayList<ContentSource> themeLayers = new ArrayList<ContentSource>();
 
+    private static final String DEFAULT_THEMES_FOLDER = "themes";
+
+    private String classpathThemesFolder;
     private String themesFolder;
     private String themeLayerNames;
     private String fileExtension;
     private int cacheMins = 0;
-
-    private static final String DEFAULT_THEMES_FOLDER = "themes";
 
     private String localeCode = null;
     private boolean renderErrs = true;
@@ -72,6 +74,10 @@ public class Theme implements ContentSource, ChunkFactory
         this.fileExtension = ext;
     }
 
+    public void setClasspathThemesFolder(String classpathThemesFolder) {
+        this.classpathThemesFolder = classpathThemesFolder;
+    }
+
     public void setTemplateFolder(String pathToTemplates)
     {
         if (this.themeLayers.size() > 0) {
@@ -116,22 +122,19 @@ public class Theme implements ContentSource, ChunkFactory
 
     private void init()
     {
+        if (classpathThemesFolder == null) classpathThemesFolder = "/" + DEFAULT_THEMES_FOLDER;
+        classpathThemesFolder = Path.ensureTrailingSeparator(classpathThemesFolder);
         if (themesFolder == null) themesFolder = DEFAULT_THEMES_FOLDER;
-        // ensure trailing fileseparator
-        char lastChar = themesFolder.charAt(themesFolder.length()-1);
-        char fs = System.getProperty("file.separator").charAt(0);
-        if (lastChar != '\\' && lastChar != '/' && lastChar != fs) {
-            themesFolder += fs;
-        }
+        themesFolder = Path.ensureTrailingSeparator(themesFolder);
 
         String[] layerNames = parseLayerNames(themeLayerNames);
         if (layerNames == null) {
-            TemplateSet simple = new TemplateSet(themesFolder, fileExtension, cacheMins);
+            TemplateSet simple = new TemplateSet(classpathThemesFolder, themesFolder, fileExtension, cacheMins);
             if (!renderErrs) simple.signalFailureWithNull();
             themeLayers.add(simple);
         } else {
             for (int i=0; i<layerNames.length; i++) {
-                TemplateSet x = new TemplateSet(this.themesFolder + layerNames[i], fileExtension, cacheMins);
+                TemplateSet x = new TemplateSet(classpathThemesFolder, themesFolder + layerNames[i], fileExtension, cacheMins);
                 x.setLayerName(layerNames[i]);
                 // do not return pretty HTML-formatted error strings
                 // when template can not be located -- with multiple

--- a/src/main/java/com/x5/template/Theme.java
+++ b/src/main/java/com/x5/template/Theme.java
@@ -13,7 +13,7 @@ public class Theme implements ContentSource, ChunkFactory
 {
     private ArrayList<ContentSource> themeLayers = new ArrayList<ContentSource>();
 
-    private static final String DEFAULT_THEMES_FOLDER = "themes";
+    public static final String DEFAULT_THEMES_FOLDER = "themes";
 
     private String classpathThemesFolder;
     private String themesFolder;
@@ -123,7 +123,6 @@ public class Theme implements ContentSource, ChunkFactory
     private void init()
     {
         if (classpathThemesFolder == null) classpathThemesFolder = "/" + DEFAULT_THEMES_FOLDER;
-        classpathThemesFolder = Path.ensureTrailingSeparator(classpathThemesFolder);
         if (themesFolder == null) themesFolder = DEFAULT_THEMES_FOLDER;
         themesFolder = Path.ensureTrailingSeparator(themesFolder);
 

--- a/src/main/java/com/x5/util/Path.java
+++ b/src/main/java/com/x5/util/Path.java
@@ -1,0 +1,14 @@
+package com.x5.util;
+
+public class Path {
+    public static String ensureTrailingSeparator(String path) {
+        if (path != null) {
+            char lastChar = path.charAt(path.length()-1);
+            char fs = System.getProperty("file.separator").charAt(0);
+            if (lastChar != '\\' && lastChar != '/' && lastChar != fs) {
+                return path + fs;
+            }
+        }
+        return path;
+    }
+}


### PR DESCRIPTION
Hi,

I'd like to add Chunk Templates to template engines benchmark: [mbosecke/template-benchmark](https://github.com/mbosecke/template-benchmark). This benchmark stores it's templates in the `jar:resources/templates/` directory. Unfortunately Chunk Templates can't read templates on classpath from different directory than `/themes/` because of hardcoded directory name in the `TemplateSet.getResourcePath` method.

I propose adding new fields Theme.classpathThemesFolder and TemplateSet.classpathThemesFolder that will allow user to change the directory name.