### PR TITLE
Fixed (classpath) path separator on Windows

### DIFF
--- a/src/main/java/com/x5/template/TemplateSet.java
+++ b/src/main/java/com/x5/template/TemplateSet.java
@@ -109,7 +109,7 @@ public class TemplateSet implements ContentSource, ChunkFactory
     private String defaultExtension = null;
     private String tagStart = DEFAULT_TAG_START;
     private String tagEnd = DEFAULT_TAG_END;
-    private String classpathThemesFolder = Path.ensureTrailingSeparator("/" + Theme.DEFAULT_THEMES_FOLDER);
+    private String classpathThemesFolder = Path.ensureTrailingPathSeparator("/" + Theme.DEFAULT_THEMES_FOLDER);
     private String templatePath = System.getProperty("templateset.folder","");
     private String layerName = null;
 
@@ -133,12 +133,12 @@ public class TemplateSet implements ContentSource, ChunkFactory
     public TemplateSet(String classpathThemesFolder, String templatePath, String extension, int refreshMins)
     {
         this(templatePath, extension, refreshMins);
-        this.classpathThemesFolder = Path.ensureTrailingSeparator(classpathThemesFolder);
+        this.classpathThemesFolder = Path.ensureTrailingPathSeparator(classpathThemesFolder);
     }
 
     public TemplateSet(String templatePath, String extension, int refreshMins)
     {
-        this.templatePath = Path.ensureTrailingSeparator(templatePath);
+        this.templatePath = Path.ensureTrailingFileSeparator(templatePath);
         this.dirtyInterval = refreshMins;
         this.defaultExtension = extension;
     }
@@ -654,7 +654,7 @@ public class TemplateSet implements ContentSource, ChunkFactory
 
     public void setLayerName(String layerName)
     {
-        this.layerName = Path.ensureTrailingSeparator(layerName);
+        this.layerName = Path.ensureTrailingFileSeparator(layerName);
     }
 
     public void setEncoding(String encoding)

--- a/src/main/java/com/x5/template/Theme.java
+++ b/src/main/java/com/x5/template/Theme.java
@@ -134,7 +134,7 @@ public class Theme implements ContentSource, ChunkFactory
     {
         if (classpathThemesFolder == null) classpathThemesFolder = "/" + DEFAULT_THEMES_FOLDER;
         if (themesFolder == null) themesFolder = DEFAULT_THEMES_FOLDER;
-        themesFolder = Path.ensureTrailingSeparator(themesFolder);
+        themesFolder = Path.ensureTrailingFileSeparator(themesFolder);
 
         String[] layerNames = parseLayerNames(themeLayerNames);
         if (layerNames == null) {

--- a/src/main/java/com/x5/util/Path.java
+++ b/src/main/java/com/x5/util/Path.java
@@ -2,13 +2,24 @@ package com.x5.util;
 
 public class Path
 {
-    public static String ensureTrailingSeparator(String path)
+    public static String ensureTrailingFileSeparator(String path)
     {
         if (path != null) {
             char lastChar = path.charAt(path.length()-1);
             char fs = System.getProperty("file.separator").charAt(0);
             if (lastChar != '\\' && lastChar != '/' && lastChar != fs) {
                 return path + fs;
+            }
+        }
+        return path;
+    }
+
+    public static String ensureTrailingPathSeparator(String path)
+    {
+        if (path != null) {
+            char lastChar = path.charAt(path.length()-1);
+            if (lastChar != '/') {
+                return path + '/';
             }
         }
         return path;

--- a/src/test/java/com/x5/template/ConfigTest.java
+++ b/src/test/java/com/x5/template/ConfigTest.java
@@ -83,7 +83,8 @@ public class ConfigTest
         ThemeConfig config = new ThemeConfig(cfg);
         Theme theme = new Theme(config);
         Chunk c = theme.makeChunk("file_that_does_not_exist");
-        assertEquals("[chtml template 'file_that_does_not_exist' not found]<!-- looked in [themes/file_that_does_not_exist.chtml] -->", c.toString());
+        String expected = "[chtml template 'file_that_does_not_exist' not found]<!-- looked in [themes%sfile_that_does_not_exist.chtml] -->";
+        assertEquals(String.format(expected, System.getProperty("file.separator")), c.toString());
 
         cfg = new HashMap<String,String>();
         cfg.put("hide_errors", "TRUE");


### PR DESCRIPTION
Hi Tom,

there was a problem with resources loaded by ClassLoader on Windows. Paths used by ClassLoader has to have forward slash used as a file separator [1] even on Windows. Unfortunately in my last pull request I used platform dependent separator which does not work on Windows [2].

This problem has been noticed in templates-benchmark project.

Please check my fix out.

1) http://docs.oracle.com/javase/1.5.0/docs/api/java/lang/ClassLoader.html#getResource(java.lang.String)
2) https://github.com/mbosecke/template-benchmark/pull/13#issuecomment-203353397