### PR TITLE
Let chunk find is<property> method, when returning Boolean

### DIFF
--- a/src/main/java/com/x5/util/ObjectDataMap.java
+++ b/src/main/java/com/x5/util/ObjectDataMap.java
@@ -2,6 +2,7 @@ package com.x5.util;
 
 import java.beans.BeanInfo;
 import java.beans.Introspector;
+import java.beans.MethodDescriptor;
 import java.beans.PropertyDescriptor;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
@@ -506,8 +507,9 @@ public class ObjectDataMap implements Map
 
             if (getters == null) {
                 PropertyDescriptor[] properties = null;
+                BeanInfo beanInfo;
                 try {
-                    BeanInfo beanInfo = Introspector.getBeanInfo(bean.getClass());
+                    beanInfo = Introspector.getBeanInfo(bean.getClass());
                     properties = beanInfo.getPropertyDescriptors();
                 } catch (java.beans.IntrospectionException e) {
                     throw new IntrospectionException();
@@ -518,7 +520,18 @@ public class ObjectDataMap implements Map
                 getters = new ArrayList<Getter>();
                 for (PropertyDescriptor property : properties) {
                     Method getter = property.getReadMethod();
-                    if (getter == null) continue;
+                    if (getter == null) {
+                        if (property.getPropertyType().equals(Boolean.class)) {
+                            String isMaybeMethod = "is" + property.getName();
+                            for (MethodDescriptor desc : beanInfo.getMethodDescriptors()) {
+                                if (desc.getName().equalsIgnoreCase(isMaybeMethod)) {
+                                    getters.add(new Getter(property, desc.getMethod()));
+                                    break;
+                                }
+                            }
+                        }
+                        continue;
+                    }
                     getters.add(new Getter(property, getter));
                 }
 

--- a/src/test/java/com/x5/template/ChunkTest.java
+++ b/src/test/java/com/x5/template/ChunkTest.java
@@ -823,11 +823,12 @@ public class ChunkTest
         Theme theme = new Theme();
         Chunk c = theme.makeChunk();
         c.append("{$x.is_active|ondefined(Active):Inactive}");
-        c.append(" {$x.has_lemons|ondefined(Lemon-Ready):Lemonless}");
+        c.append(" {$x.is_has_lemons|ondefined(Lemon-Ready):Lemonless}");
         ThingBean bean = new ThingBean();
         c.set("x", bean);
         bean.setActive(true);
-        assertEquals("Active Lemonless", c.toString());
+        bean.setHasLemons(true);
+        assertEquals("Active Lemon-Ready", c.toString());
     }
 
     @Test
@@ -1117,7 +1118,7 @@ public class ChunkTest
             return isActive;
         }
 
-        public Boolean getHasLemons()
+        public Boolean isHasLemons()
         {
             return hasLemons;
         }
@@ -1151,6 +1152,8 @@ public class ChunkTest
         {
             this.isActive = isActive;
         }
+
+        public void setHasLemons(Boolean hasLemons) { this.hasLemons = hasLemons; }
 
         public void setBoss(ThingBean boss)
         {


### PR DESCRIPTION
Having a Boolean property, chunk only recognizes its read methods,
when the methos id called 'get<property>'. Fix this by making
Boolean an exception and search for its is<property> method
explicitly.

Signed-off-by: Dana Kutenicsova <dkutenicsova@frinx.io>